### PR TITLE
fix: react callback usage

### DIFF
--- a/playground/src/renderer/react.tsx
+++ b/playground/src/renderer/react.tsx
@@ -27,7 +27,29 @@ export const createRendererReact: RendererFactory = (options): RendererFactoryRe
 
     console.log('React rendering', count)
 
-    return <ShikiStreamRenderer {...props} className={props.class} />
+    const [i, setI] = React.useState(0)
+
+    React.useEffect(() => {
+      const timerId = setInterval(() => {
+        setI(i => i + 1)
+      }, 1_000)
+      return () => clearInterval(timerId)
+    }, [])
+
+    return (
+      <ShikiStreamRenderer
+        {...props}
+        onStreamStart={() => {
+          console.log('onStreamStart', i)
+          props.onStreamStart?.()
+        }}
+        onStreamEnd={() => {
+          console.log('onStreamEnd', i)
+          props.onStreamEnd?.()
+        }}
+        className={props.class}
+      />
+    )
   }
 
   return {

--- a/playground/src/renderer/react.tsx
+++ b/playground/src/renderer/react.tsx
@@ -16,11 +16,10 @@ export const createRendererReact: RendererFactory = (options): RendererFactoryRe
   })
 
   function App(): JSX.Element {
-    // TODO: make React not render twice
     const [count, setCounter] = React.useState(0)
 
     React.useEffect(() => {
-      watch(props, () => {
+      return watch(props, () => {
         // Force React to re-render
         setCounter(c => c + 1)
       })

--- a/src/react/utils.ts
+++ b/src/react/utils.ts
@@ -1,0 +1,24 @@
+// source: https://github.com/sanity-io/use-effect-event/blob/main/src/useEffectEvent.ts
+import { useCallback, useInsertionEffect, useRef } from 'react'
+
+/**
+ * This is a ponyfill of the upcoming `useEffectEvent` hook that'll arrive in React 19.
+ * https://19.react.dev/learn/separating-events-from-effects#declaring-an-effect-event
+ * To learn more about the ponyfill itself, see: https://blog.bitsrc.io/a-look-inside-the-useevent-polyfill-from-the-new-react-docs-d1c4739e8072
+ * @public
+ */
+export function useEffectEvent<
+  const T extends (
+    ...args:
+    any[]
+  ) => void,
+>(fn: T): T {
+  const ref = useRef<T | null>(null)
+  useInsertionEffect(() => {
+    ref.current = fn
+  }, [fn])
+  return useCallback((...args: any) => {
+    const latestFn = ref.current!
+    return latestFn(...args)
+  }, []) as unknown as T
+}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Use [`useEffectEvent`](https://react.dev/learn/separating-events-from-effects#extracting-non-reactive-logic-out-of-effects) to wrap callback fn from props, mark it as non-reactive and safely put in deps array of `useEffect`. Also, fix the stale closure issue of the original implementation, that the end callback would be called as the snapshot of the time when the stream changed (like the screenshot below, two callback log same value).

|Before|After|
|---|---|
|<img width="140" alt="image" src="https://github.com/user-attachments/assets/4b1297f8-c731-4314-9db3-4d5f970e5c82" />|<img width="135" alt="image" src="https://github.com/user-attachments/assets/ab006d4c-45e0-4a03-9fdc-3f66082440e4" />|

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
